### PR TITLE
Adds component.json with jquery depenency

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,8 @@
+{
+  "name": "jquery-ui",
+  "version": "1.8.23",
+  "main": "./jquery-ui.js",
+  "dependencies": {
+    "jquery": "~1.8.1"
+  }
+}


### PR DESCRIPTION
If a git repo doesn't have a component.json, bower will try to use the package.json instead, but jQuery UI's package.json doesn't list jQuery as a dependency. :(

With the component.json in this commit, bower installs jQuery, too! :D
