### PR TITLE
Fix Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,12 +49,8 @@
                 "ui/jquery-ui.js"
             ],
             "files": [
-                "ui/jquery.ui.*.js",
-                "ui/i18n/*.js",
-                "ui/minified/*.js",
-                "ui/minified/i18n/*.js",
-                "themes/*/*",
-                "themes/*/*/*"
+                "ui/**",
+                "themes/**"
             ],
             "shim": {
                 "deps": [


### PR DESCRIPTION
This fixes up the file references for the new version of jQuery UI for Composer. jQuery reference is handled by the shim definition.
