### PR TITLE
Relaxed jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
     "ui/jquery-ui.js"
   ],
   "dependencies": {
-    "jquery": "~> 1.10.1"
+    "jquery": ">=1.6"
   }
 }


### PR DESCRIPTION
According to http://jqueryui.com/, this is the minimum required version. This also allows using of jquery-ui with jquery 2.0, without conflict resolution.
