### PR TITLE
Update component.json so jquery-ui is loadable

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,6 +6,7 @@
   "scripts": [
     "ui/jquery-ui.js"
   ],
+  "main": "ui/jquery-ui.js",
   "dependencies": {
     "components/jquery": ">= 1.8"
   }


### PR DESCRIPTION
Currently without the "main" property, require("jquery-ui") does not do anything. Adding the "main" property tells component that "ui/jquery-ui.js" takes the place of the index file so that the file is loaded when required.
