### PR TITLE
Add empty ignore array to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,8 @@
   "main": [
     "jquery-ui.js"
   ],
+  "ignore": [
+  ],
   "dependencies": {
     "jquery": ">=1.6"
   }


### PR DESCRIPTION
Bower throws a in “invalid-meta” warning saying “jquery-ui is missing
"ignore" entry in bower.json” when this array is not available.

Addresses #37
