### PR TITLE
Missing main attribute in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 			"url": "https://github.com/jquery/jquery-ui/blob/1-11-stable/LICENSE.txt"
 		}
 	],
+	"main": "jquery-ui.js",
 	"dependencies": {},
 	"devDependencies": {
 		"grunt": "~0.3.17",


### PR DESCRIPTION
Thanks for building jQuery UI and making it available.  Any reason you don't set the main attribute in package.json?  This would allow module loaders to work with your package without shimming it.